### PR TITLE
Add configuration support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://github.com/travipross/fuel-logger-r"
 anyhow = "1.0.86"
 axum = "0.7.5"
 chrono = { version = "0.4.38", features = ["serde"] }
+config = "0.14.1"
 fake = { version = "2.9.2", features = [
     "derive",
     "chrono",
@@ -20,6 +21,7 @@ fake = { version = "2.9.2", features = [
 rand = "0.8.5"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
+serde_yaml2 = "0.1.2"
 sqlx = { version = "0.8.0", features = [
     "runtime-tokio",
     "tls-rustls",
@@ -34,5 +36,7 @@ uuid = { version = "1.10.0", features = ["v4", "serde"] }
 [dev-dependencies]
 axum-test = "16.4.0"
 itertools = "0.13.0"
+temp-env = "0.3.6"
+tempfile = "3.14.0"
 test-case = "3.3.1"
 tower = { version = "0.5.1", features = ["util"] }

--- a/dev/example-config.yml
+++ b/dev/example-config.yml
@@ -1,0 +1,6 @@
+server:
+  port: 3000
+  host: 0.0.0.0
+
+database:
+  url: postgresql://user:password@localhost:5432

--- a/justfile
+++ b/justfile
@@ -110,7 +110,7 @@ db-migrate-down:
 # Connect to database
 [group('database')]
 db-connect:
-    docker compose -f {{docker-compose-path}} exec db psql ${DATABASE_URL}
+    docker compose -f {{docker-compose-path}} exec db psql ${VL__DATABASE_URL}
 
 # Create new migration
 [group('database')]
@@ -140,10 +140,10 @@ init-env:
         SETTINGS_JSON=$(cat <<EOF
     {
         "rust-analyzer.cargo.extraEnv": {
-            "DATABASE_URL": "${DATABASE_URL}"
+            "VL__DATABASE_URL": "${DATABASE_URL}"
         },
         "rust-analyzer.runnables.extraEnv": {
-            "DATABASE_URL": "${DATABASE_URL}"
+            "VL__DATABASE_URL": "${DATABASE_URL}"
         },
         "rust-analyzer.cargo.extraArgs": [
             "--all-features"
@@ -168,5 +168,6 @@ init-env:
     POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     POSTGRES_USER=${POSTGRES_USER}
     DATABASE_URL=${DATABASE_URL}
+    VL__DATABASE_URL=${DATABASE_URL}
     EOF
     fi

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,189 @@
+use crate::{
+    error::ApiError,
+    types::{configuration::ServerHost, ServerPort},
+};
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, fake::Dummy, Default)]
+#[serde(default)]
+#[serde(deny_unknown_fields)]
+pub struct ServerConfig {
+    pub port: ServerPort,
+    pub host: ServerHost,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, fake::Dummy, Default)]
+#[serde(deny_unknown_fields)]
+pub struct DatabaseConfig {
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, fake::Dummy, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Configuration {
+    #[serde(default)]
+    pub server: ServerConfig,
+    pub database: DatabaseConfig,
+}
+
+pub fn read_config() -> Result<Configuration, ApiError> {
+    let config_file_path = std::env::var("CONFIG_FILE").unwrap_or("config.yml".into());
+    let raw_config = config::Config::builder()
+        .add_source(config::File::with_name(&config_file_path).required(false))
+        .add_source(
+            config::Environment::with_prefix("VL")
+                .separator("_")
+                .prefix_separator("__"),
+        )
+        .build()?;
+
+    Ok(raw_config.try_deserialize::<Configuration>()?)
+}
+
+#[cfg(test)]
+mod test_utils {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    pub(crate) fn write_config_to_temp_yaml_file(config: &Configuration) -> NamedTempFile {
+        let mut tmp_config =
+            tempfile::NamedTempFile::with_suffix(".yaml").expect("could not create tempfile");
+        let config_yaml_string =
+            serde_yaml2::to_string(config).expect("could not build yaml string");
+        tmp_config
+            .write_all(config_yaml_string.as_bytes())
+            .expect("could not write to file");
+        tmp_config
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+    use fake::{Fake, Faker};
+    use test_utils::write_config_to_temp_yaml_file;
+
+    #[test]
+    fn test_read_from_env() {
+        // Arrange
+        let port = (1024..49151).fake::<u16>();
+        let host = "0.0.0.1";
+        let db_url = "psql://user:pass@localhost/fuel:5432";
+
+        temp_env::with_vars(
+            [
+                ("VL__SERVER_PORT", Some(port.to_string())),
+                ("VL__SERVER_HOST", Some(host.to_owned())),
+                ("VL__DATABASE_URL", Some(db_url.to_owned())),
+            ],
+            || {
+                // Act
+                let config = read_config().expect("could not read config");
+
+                // Assert
+                assert_eq!(port, config.server.port);
+                assert_eq!(host, config.server.host.as_str());
+                assert_eq!(db_url, config.database.url);
+            },
+        )
+    }
+
+    #[test]
+    fn test_read_from_yaml() {
+        // Arrange
+        let config = Faker.fake::<Configuration>();
+        let tmp_config = write_config_to_temp_yaml_file(&config);
+
+        temp_env::with_vars(
+            [
+                ("CONFIG_FILE", Some(tmp_config.path())),
+                ("VL__DATABASE_URL", None),
+            ],
+            || {
+                // Act
+                let loaded_config = read_config().expect("could not read config");
+
+                // Assert
+                assert_eq!(loaded_config, config);
+            },
+        )
+    }
+
+    #[test]
+    fn env_takes_precedence_over_file() {
+        // Arrange
+        let config = Faker.fake::<Configuration>();
+        let tmp_config = write_config_to_temp_yaml_file(&config);
+        let port_override = (1024..49151).fake::<u16>();
+        temp_env::with_vars(
+            [
+                (
+                    "CONFIG_FILE",
+                    Some(format!("{}", tmp_config.path().display())),
+                ),
+                ("VL__SERVER_PORT", Some(port_override.to_string())),
+            ],
+            || {
+                // Act
+                let loaded_config = read_config().expect("could not read config");
+
+                // Assert
+                assert_ne!(loaded_config, config);
+                assert_eq!(loaded_config.server.port, port_override);
+            },
+        )
+    }
+
+    #[test]
+    fn ignores_file_if_nonexistent() {
+        // Arrange
+        let config = Faker.fake::<Configuration>();
+
+        temp_env::with_vars(
+            [
+                ("CONFIG_FILE", Some(Faker.fake())),
+                ("VL__SERVER_PORT", Some(config.server.port.to_string())),
+                ("VL__SERVER_HOST", Some(config.server.host.to_string())),
+                ("VL__DATABASE_URL", Some(config.database.url.to_string())),
+            ],
+            || {
+                // Act
+                let loaded_config = read_config().expect("could not read config");
+
+                // Assert
+                assert_eq!(loaded_config, config);
+            },
+        )
+    }
+
+    #[test]
+    fn uses_defaults_if_not_set() {
+        // Arrange
+        let db_url = Faker.fake::<String>();
+
+        temp_env::with_var("VL__DATABASE_URL", Some(db_url.clone()), || {
+            // Act
+            let loaded_config = read_config().expect("could not read config");
+
+            // Assert
+            assert_eq!(
+                loaded_config,
+                Configuration {
+                    database: DatabaseConfig { url: db_url },
+                    ..Default::default()
+                }
+            )
+        })
+    }
+
+    #[test]
+    fn example_config_is_valid() {
+        // Arrange
+        let config = config::Config::builder()
+            .add_source(config::File::with_name("dev/example-config.yml"))
+            .build()
+            .expect("could not read from file");
+        let deserialized = config.try_deserialize::<Configuration>();
+        assert!(deserialized.is_ok(), "{deserialized:?}")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
-mod controllers;
-mod error;
+pub mod configuration;
+pub mod controllers;
+pub mod error;
 pub mod models;
-mod routes;
+pub mod routes;
 pub mod types;
-mod utils;
+pub mod utils;
 
 use axum::Router;
 use routes::{log_records, users, vehicles};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,30 @@
 use anyhow::Context;
 use axum::serve;
-use fuel_logger_rs::build_router;
+use fuel_logger_rs::{build_router, configuration::read_config};
 use sqlx::postgres::PgPoolOptions;
-use std::{env, time::Duration};
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let database_url = env::var("DATABASE_URL")?;
-
+    let config = read_config().context("failed to load configuration")?;
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .acquire_timeout(Duration::from_secs(5))
-        .connect(&database_url)
+        .connect(&config.database.url)
         .await
         .context("can't connect to database")?;
 
     // Build main app router
     let app = build_router(&pool);
 
-    let port = env::var("PORT").unwrap_or("3000".to_owned());
+    // let port = env::var("PORT").unwrap_or("3000".to_owned());
+    let addr = format!("{}:{}", config.server.host, config.server.port);
 
     // run our app with hyper, listening globally on port 3000
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+    let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .context("failed to create TCP listener")?;
-    println!("Running on: localhost:{port}");
+    println!("Running on: {addr}");
     serve(listener, app)
         .await
         .context("failed to serve axum app")?;

--- a/src/types/configuration/mod.rs
+++ b/src/types/configuration/mod.rs
@@ -1,0 +1,5 @@
+mod server_host;
+mod server_port;
+
+pub use server_host::ServerHost;
+pub use server_port::ServerPort;

--- a/src/types/configuration/server_host.rs
+++ b/src/types/configuration/server_host.rs
@@ -1,0 +1,49 @@
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, fake::Dummy)]
+#[serde(transparent)]
+pub struct ServerHost(#[dummy(faker = "fake::faker::internet::en::IPv4()")] String);
+
+impl Default for ServerHost {
+    fn default() -> Self {
+        Self("0.0.0.0".to_owned())
+    }
+}
+
+impl Display for ServerHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::ops::Deref for ServerHost {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq<String> for ServerHost {
+    fn eq(&self, other: &String) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<ServerHost> for String {
+    fn eq(&self, other: &ServerHost) -> bool {
+        *self == other.0
+    }
+}
+
+impl From<String> for ServerHost {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ServerHost> for String {
+    fn from(value: ServerHost) -> Self {
+        value.0
+    }
+}

--- a/src/types/configuration/server_port.rs
+++ b/src/types/configuration/server_port.rs
@@ -1,0 +1,57 @@
+use std::{fmt::Display, ops::Deref};
+
+use fake::Faker;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct ServerPort(u16);
+
+impl Display for ServerPort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Default for ServerPort {
+    fn default() -> Self {
+        Self(3000)
+    }
+}
+
+impl fake::Dummy<Faker> for ServerPort {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_config: &Faker, rng: &mut R) -> Self {
+        Self(rng.gen_range(1024..=49151))
+    }
+}
+
+impl Deref for ServerPort {
+    type Target = u16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq<u16> for ServerPort {
+    fn eq(&self, other: &u16) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<ServerPort> for u16 {
+    fn eq(&self, other: &ServerPort) -> bool {
+        *self == other.0
+    }
+}
+
+impl From<u16> for ServerPort {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ServerPort> for u16 {
+    fn from(value: ServerPort) -> Self {
+        value.0
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,8 @@
+pub mod configuration;
 pub mod log_type;
 pub mod primitives;
 
+pub use configuration::ServerPort;
 pub use log_type::LogType;
 pub use primitives::{
     BrakeComponent, BrakeLocation, FluidType, OdometerUnit, TireRotationType, TireType,


### PR DESCRIPTION
* Use `config` crate to provide configuration support
* server host, server port, and database url are now obtained from main config instead of separate env vars
* setup scripts updated to create default vars by new required name (with `VL__` prefix)
* newtypes created for `ServerPort` and `ServerHost` for easier faking

